### PR TITLE
fix #6: support non standard dh key size by using bouncy castle provider

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@ sshd server and use port forwarding, X11 forwarding, file transfer, etc., and
 you can integrate its functionality into your own Java programs
     </description>
   <!-- set global properties for this build -->
-  <property name="version" value="0.1.53"/>
+  <property name="version" value="0.1.53.2"/>
   <property name="src" location="src/main/java/"/>
   <property name="exasrc" location="examples"/>
   <property name="build" location="build"/>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.jcraft</groupId>
   <artifactId>jsch</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.53</version>
+  <version>0.1.53.2</version>
   <name>JSch</name>
   <url>http://www.jcraft.com/jsch/</url>
   <description>JSch is a pure Java implementation of SSH2</description>
@@ -45,6 +45,13 @@
       <version>1.0.7</version>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk16</artifactId>
+      <version>1.46</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -78,6 +78,7 @@ public class JSch {
 
         config.put("ecdh-sha2-nistp", "com.jcraft.jsch.jce.ECDHN");
 
+        config.put(com.jcraft.jsch.jce.DH.KEY_BOUNCY_CASTLE_ENABLE, "true");
         config.put("dh", "com.jcraft.jsch.jce.DH");
         config.put("3des-cbc", "com.jcraft.jsch.jce.TripleDESCBC");
         config.put("blowfish-cbc", "com.jcraft.jsch.jce.BlowfishCBC");

--- a/src/main/java/com/jcraft/jsch/jce/DH.java
+++ b/src/main/java/com/jcraft/jsch/jce/DH.java
@@ -29,6 +29,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 
 import javax.crypto.KeyAgreement;
@@ -41,6 +42,9 @@ import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 
 public class DH implements com.jcraft.jsch.DH {
+
+    public static final String KEY_BOUNCY_CASTLE_ENABLE = "dh.bouncycastle.enable";
+
     BigInteger p;
     BigInteger g;
     BigInteger e;  // my public key
@@ -53,7 +57,12 @@ public class DH implements com.jcraft.jsch.DH {
     private KeyAgreement myKeyAgree;
 
     public void init() throws Exception {
-        myKpairGen = KeyPairGenerator.getInstance("DH");
+        if ("TRUE".equalsIgnoreCase(JSch.getConfig(KEY_BOUNCY_CASTLE_ENABLE))) {
+            myKpairGen = new org.bouncycastle.jce.provider.JDKKeyPairGenerator.DH();
+        }
+        else {
+            myKpairGen = KeyPairGenerator.getInstance("DH");
+        }
         myKeyAgree = KeyAgreement.getInstance("DH");
     }
 


### PR DESCRIPTION
Provide a config item to decide whether to enable this feature (default is enable).
```
    JSch.setConfig("dh.bouncycastle.enable", "true");
```
